### PR TITLE
Isolate request validation

### DIFF
--- a/application/services/dummy/CREATE/request.go
+++ b/application/services/dummy/CREATE/request.go
@@ -1,19 +1,23 @@
 package dummy
 
 import (
-	domain "go-skeleton/application/domain/dummy"
 	"go-skeleton/application/services"
 )
 
+type RequestDTO struct {
+	DummyId   string
+	DummyName string `validate:"required,min=3,max=32" json:"dummy_name"`
+}
+
 type Request struct {
-	Dummy     domain.Dummy
+	DTO       *RequestDTO
 	Err       error
 	validator services.Validator
 }
 
-func NewRequest(dummy domain.Dummy, validator services.Validator) Request {
+func NewRequest(dto *RequestDTO, validator services.Validator) Request {
 	return Request{
-		Dummy:     dummy,
+		DTO:       dto,
 		validator: validator,
 	}
 }
@@ -22,7 +26,7 @@ func (r *Request) Validate() error {
 	if err := r.dummyCreateRule(); err != nil {
 		return err
 	}
-	errs := r.validator.ValidateStruct(r.Dummy)
+	errs := r.validator.ValidateStruct(r.DTO)
 	for _, err := range errs {
 		if err != nil {
 			return err

--- a/application/services/dummy/CREATE/request.go
+++ b/application/services/dummy/CREATE/request.go
@@ -4,20 +4,20 @@ import (
 	"go-skeleton/application/services"
 )
 
-type RequestDTO struct {
+type Data struct {
 	DummyId   string
 	DummyName string `validate:"required,min=3,max=32" json:"dummy_name"`
 }
 
 type Request struct {
-	DTO       *RequestDTO
+	Data      *Data
 	Err       error
 	validator services.Validator
 }
 
-func NewRequest(dto *RequestDTO, validator services.Validator) Request {
+func NewRequest(data *Data, validator services.Validator) Request {
 	return Request{
-		DTO:       dto,
+		Data:      data,
 		validator: validator,
 	}
 }
@@ -26,7 +26,7 @@ func (r *Request) Validate() error {
 	if err := r.dummyCreateRule(); err != nil {
 		return err
 	}
-	errs := r.validator.ValidateStruct(r.DTO)
+	errs := r.validator.ValidateStruct(r.Data)
 	for _, err := range errs {
 		if err != nil {
 			return err

--- a/application/services/dummy/CREATE/service.go
+++ b/application/services/dummy/CREATE/service.go
@@ -31,18 +31,18 @@ func (s *Service) Execute(request Request) {
 		return
 	}
 
-	request.DTO.DummyId = s.idCreator.Create()
-	s.produceResponseRule(request.DTO)
+	request.Data.DummyId = s.idCreator.Create()
+	s.produceResponseRule(request.Data)
 }
 
 func (s *Service) GetResponse() (*Response, *services.Error) {
 	return s.response, s.Error
 }
 
-func (s *Service) produceResponseRule(dto *RequestDTO) {
+func (s *Service) produceResponseRule(data *Data) {
 	dummy := dummy.Dummy{
-		DummyId:   dto.DummyId,
-		DummyName: dto.DummyName,
+		DummyId:   data.DummyId,
+		DummyName: data.DummyName,
 	}
 	err := s.repository.Create(&dummy)
 	if err != nil {

--- a/application/services/dummy/CREATE/service.go
+++ b/application/services/dummy/CREATE/service.go
@@ -31,15 +31,19 @@ func (s *Service) Execute(request Request) {
 		return
 	}
 
-	request.Dummy.DummyId = s.idCreator.Create()
-	s.produceResponseRule(request.Dummy)
+	request.DTO.DummyId = s.idCreator.Create()
+	s.produceResponseRule(request.DTO)
 }
 
 func (s *Service) GetResponse() (*Response, *services.Error) {
 	return s.response, s.Error
 }
 
-func (s *Service) produceResponseRule(dummy dummy.Dummy) {
+func (s *Service) produceResponseRule(dto *RequestDTO) {
+	dummy := dummy.Dummy{
+		DummyId:   dto.DummyId,
+		DummyName: dto.DummyName,
+	}
 	err := s.repository.Create(&dummy)
 	if err != nil {
 		s.Error = &services.Error{

--- a/application/services/dummy/DELETE/request.go
+++ b/application/services/dummy/DELETE/request.go
@@ -1,17 +1,17 @@
 package dummy
 
-type RequestDTO struct {
+type Data struct {
 	DummyId string `param:"dummy_id"`
 }
 
 type Request struct {
-	DTO *RequestDTO
-	Err error
+	Data *Data
+	Err  error
 }
 
-func NewRequest(dto *RequestDTO) Request {
+func NewRequest(data *Data) Request {
 	return Request{
-		DTO: dto,
+		Data: data,
 	}
 }
 

--- a/application/services/dummy/DELETE/request.go
+++ b/application/services/dummy/DELETE/request.go
@@ -1,19 +1,17 @@
 package dummy
 
-import (
-	domain "go-skeleton/application/domain/dummy"
-)
-
-type Request struct {
-	Err   error
-	dummy domain.Dummy
+type RequestDTO struct {
+	DummyId string `param:"dummy_id"`
 }
 
-func NewRequest(dummyId string) Request {
+type Request struct {
+	DTO *RequestDTO
+	Err error
+}
+
+func NewRequest(dto *RequestDTO) Request {
 	return Request{
-		dummy: domain.Dummy{
-			DummyId: dummyId,
-		},
+		DTO: dto,
 	}
 }
 

--- a/application/services/dummy/DELETE/service.go
+++ b/application/services/dummy/DELETE/service.go
@@ -27,16 +27,21 @@ func (s *Service) Execute(request Request) {
 		s.BadRequest(request, err)
 		return
 	}
-	s.produceResponseRule(request.dummy)
+	s.produceResponseRule(request.DTO)
 }
 
 func (s *Service) GetResponse() (*Response, *services.Error) {
 	return s.response, s.Error
 }
 
-func (s *Service) produceResponseRule(d dummy.Dummy) {
+func (s *Service) produceResponseRule(dto *RequestDTO) {
 	s.Logger.Debug("ProduceResponseRule")
-	err := s.repository.Delete(&d)
+
+	dummy := dummy.Dummy{
+		DummyId: dto.DummyId,
+	}
+
+	err := s.repository.Delete(&dummy)
 	if err != nil {
 		s.Error = &services.Error{
 			Status:  400,

--- a/application/services/dummy/DELETE/service.go
+++ b/application/services/dummy/DELETE/service.go
@@ -27,18 +27,18 @@ func (s *Service) Execute(request Request) {
 		s.BadRequest(request, err)
 		return
 	}
-	s.produceResponseRule(request.DTO)
+	s.produceResponseRule(request.Data)
 }
 
 func (s *Service) GetResponse() (*Response, *services.Error) {
 	return s.response, s.Error
 }
 
-func (s *Service) produceResponseRule(dto *RequestDTO) {
+func (s *Service) produceResponseRule(data *Data) {
 	s.Logger.Debug("ProduceResponseRule")
 
 	dummy := dummy.Dummy{
-		DummyId: dto.DummyId,
+		DummyId: data.DummyId,
 	}
 
 	err := s.repository.Delete(&dummy)

--- a/application/services/dummy/EDIT/request.go
+++ b/application/services/dummy/EDIT/request.go
@@ -2,30 +2,31 @@ package dummy
 
 import (
 	"errors"
-	domain "go-skeleton/application/domain/dummy"
 	"go-skeleton/application/services"
 )
 
+type RequestDTO struct {
+	DummyId   string `param:"dummy_id"`
+	DummyName string `json:"dummy_name"`
+}
+
 type Request struct {
-	Dummy     domain.Dummy
-	Dummyid   string
+	DTO       *RequestDTO
 	validator services.Validator
 }
 
-func NewRequest(dummy domain.Dummy, dummyId string, validator services.Validator) Request {
-	req := Request{
-		Dummy:     dummy,
+func NewRequest(dto *RequestDTO, validator services.Validator) Request {
+	return Request{
+		DTO:       dto,
 		validator: validator,
 	}
-	req.Dummy.DummyId = dummyId
-	return req
 }
 
 func (r *Request) Validate() error {
 	if err := r.dummyIdRule(); err != nil {
 		return err
 	}
-	errs := r.validator.ValidateStruct(r.Dummy)
+	errs := r.validator.ValidateStruct(r.DTO)
 	for _, err := range errs {
 		if err != nil {
 			return err
@@ -35,7 +36,7 @@ func (r *Request) Validate() error {
 }
 
 func (r *Request) dummyIdRule() error {
-	if r.Dummy.DummyId == `""` {
+	if r.DTO.DummyId == `""` {
 		return errors.New("invalid_argument")
 	}
 	return nil

--- a/application/services/dummy/EDIT/request.go
+++ b/application/services/dummy/EDIT/request.go
@@ -5,19 +5,19 @@ import (
 	"go-skeleton/application/services"
 )
 
-type RequestDTO struct {
+type Data struct {
 	DummyId   string `param:"dummy_id"`
 	DummyName string `json:"dummy_name"`
 }
 
 type Request struct {
-	DTO       *RequestDTO
+	Data      *Data
 	validator services.Validator
 }
 
-func NewRequest(dto *RequestDTO, validator services.Validator) Request {
+func NewRequest(data *Data, validator services.Validator) Request {
 	return Request{
-		DTO:       dto,
+		Data:      data,
 		validator: validator,
 	}
 }
@@ -26,7 +26,7 @@ func (r *Request) Validate() error {
 	if err := r.dummyIdRule(); err != nil {
 		return err
 	}
-	errs := r.validator.ValidateStruct(r.DTO)
+	errs := r.validator.ValidateStruct(r.Data)
 	for _, err := range errs {
 		if err != nil {
 			return err
@@ -36,7 +36,7 @@ func (r *Request) Validate() error {
 }
 
 func (r *Request) dummyIdRule() error {
-	if r.DTO.DummyId == `""` {
+	if r.Data.DummyId == `""` {
 		return errors.New("invalid_argument")
 	}
 	return nil

--- a/application/services/dummy/EDIT/service.go
+++ b/application/services/dummy/EDIT/service.go
@@ -28,17 +28,17 @@ func (s *Service) Execute(request Request) {
 		return
 	}
 
-	s.produceResponseRule(request.DTO)
+	s.produceResponseRule(request.Data)
 }
 
 func (s *Service) GetResponse() (*Response, *services.Error) {
 	return s.response, s.Error
 }
 
-func (s *Service) produceResponseRule(dto *RequestDTO) {
+func (s *Service) produceResponseRule(data *Data) {
 	dummy := dummy.Dummy{
-		DummyId:   dto.DummyId,
-		DummyName: dto.DummyName,
+		DummyId:   data.DummyId,
+		DummyName: data.DummyName,
 	}
 
 	err := s.repository.Edit(&dummy)

--- a/application/services/dummy/EDIT/service.go
+++ b/application/services/dummy/EDIT/service.go
@@ -28,15 +28,20 @@ func (s *Service) Execute(request Request) {
 		return
 	}
 
-	s.produceResponseRule(&request.Dummy)
+	s.produceResponseRule(request.DTO)
 }
 
 func (s *Service) GetResponse() (*Response, *services.Error) {
 	return s.response, s.Error
 }
 
-func (s *Service) produceResponseRule(dummy *dummy.Dummy) {
-	err := s.repository.Edit(dummy)
+func (s *Service) produceResponseRule(dto *RequestDTO) {
+	dummy := dummy.Dummy{
+		DummyId:   dto.DummyId,
+		DummyName: dto.DummyName,
+	}
+
+	err := s.repository.Edit(&dummy)
 	if err != nil {
 		s.Error = &services.Error{
 			Status:  400,

--- a/application/services/dummy/GET/request.go
+++ b/application/services/dummy/GET/request.go
@@ -4,18 +4,18 @@ import (
 	"errors"
 )
 
-type RequestDTO struct {
+type Data struct {
 	DummyId string `param:"dummy_id"`
 }
 
 type Request struct {
-	DTO *RequestDTO
-	Err error
+	Data *Data
+	Err  error
 }
 
-func NewRequest(dto *RequestDTO) Request {
+func NewRequest(data *Data) Request {
 	return Request{
-		DTO: dto,
+		Data: data,
 	}
 }
 
@@ -27,7 +27,7 @@ func (r *Request) Validate() error {
 }
 
 func (r *Request) dummyIdRule() error {
-	if r.DTO.DummyId == `""` {
+	if r.Data.DummyId == `""` {
 		return errors.New("invalid_argument")
 	}
 	return nil

--- a/application/services/dummy/GET/request.go
+++ b/application/services/dummy/GET/request.go
@@ -2,19 +2,20 @@ package dummy
 
 import (
 	"errors"
-	domain "go-skeleton/application/domain/dummy"
 )
 
-type Request struct {
-	Dummy domain.Dummy
-	Err   error
+type RequestDTO struct {
+	DummyId string `param:"dummy_id"`
 }
 
-func NewRequest(dummyId string) Request {
+type Request struct {
+	DTO *RequestDTO
+	Err error
+}
+
+func NewRequest(dto *RequestDTO) Request {
 	return Request{
-		Dummy: domain.Dummy{
-			DummyId: dummyId,
-		},
+		DTO: dto,
 	}
 }
 
@@ -26,7 +27,7 @@ func (r *Request) Validate() error {
 }
 
 func (r *Request) dummyIdRule() error {
-	if r.Dummy.DummyId == `""` {
+	if r.DTO.DummyId == `""` {
 		return errors.New("invalid_argument")
 	}
 	return nil

--- a/application/services/dummy/GET/service.go
+++ b/application/services/dummy/GET/service.go
@@ -27,16 +27,16 @@ func (s *Service) Execute(request Request) {
 		s.BadRequest(request, err)
 		return
 	}
-	s.produceResponseRule(request.DTO)
+	s.produceResponseRule(request.Data)
 }
 
 func (s *Service) GetResponse() (*Response, *services.Error) {
 	return s.response, s.Error
 }
 
-func (s *Service) produceResponseRule(dto *RequestDTO) {
+func (s *Service) produceResponseRule(data *Data) {
 	s.Logger.Debug("ProduceResponseRule")
-	dummyData, err := s.repository.Get(dto.DummyId)
+	dummyData, err := s.repository.Get(data.DummyId)
 	if err != nil {
 		s.Error = &services.Error{
 			Status:  400,

--- a/application/services/dummy/GET/service.go
+++ b/application/services/dummy/GET/service.go
@@ -27,16 +27,16 @@ func (s *Service) Execute(request Request) {
 		s.BadRequest(request, err)
 		return
 	}
-	s.produceResponseRule(request.Dummy.DummyId)
+	s.produceResponseRule(request.DTO)
 }
 
 func (s *Service) GetResponse() (*Response, *services.Error) {
 	return s.response, s.Error
 }
 
-func (s *Service) produceResponseRule(id string) {
+func (s *Service) produceResponseRule(dto *RequestDTO) {
 	s.Logger.Debug("ProduceResponseRule")
-	dummyData, err := s.repository.Get(id)
+	dummyData, err := s.repository.Get(dto.DummyId)
 	if err != nil {
 		s.Error = &services.Error{
 			Status:  400,

--- a/application/services/dummy/LIST/request.go
+++ b/application/services/dummy/LIST/request.go
@@ -1,12 +1,7 @@
 package dummy
 
-import (
-	domain "go-skeleton/application/domain/dummy"
-)
-
 type Request struct {
-	Dummy []domain.Dummy
-	Err   error
+	Err error
 }
 
 func NewRequest() Request {

--- a/cmd/http/handlers/dummy.go
+++ b/cmd/http/handlers/dummy.go
@@ -1,9 +1,6 @@
 package handlers
 
 import (
-	"encoding/json"
-	"github.com/labstack/echo/v4"
-	"go-skeleton/application/domain/dummy"
 	dummyCreate "go-skeleton/application/services/dummy/CREATE"
 	dummyDelete "go-skeleton/application/services/dummy/DELETE"
 	dummyEdit "go-skeleton/application/services/dummy/EDIT"
@@ -15,7 +12,8 @@ import (
 	"go-skeleton/pkg/logger"
 	dummyRepository "go-skeleton/pkg/repositories/dummy"
 	"go-skeleton/pkg/validator"
-	"io"
+
+	"github.com/labstack/echo/v4"
 )
 
 type DummyHandlers struct {
@@ -48,8 +46,14 @@ func NewDummyHandlers(
 
 func (hs *DummyHandlers) HandleGetDummy(context echo.Context) error {
 	s := dummyGet.NewService(hs.logger, hs.DummyRepository)
+	dto := new(dummyGet.RequestDTO)
+
+	if errors := context.Bind(dto); errors != nil {
+		return context.JSON(422, errors)
+	}
+
 	s.Execute(
-		dummyGet.NewRequest(context.Param("dummy_id")),
+		dummyGet.NewRequest(dto),
 	)
 	response, err := s.GetResponse()
 	if err != nil {
@@ -60,20 +64,14 @@ func (hs *DummyHandlers) HandleGetDummy(context echo.Context) error {
 
 func (hs *DummyHandlers) HandleCreateDummy(context echo.Context) error {
 	s := dummyCreate.NewService(hs.logger, hs.DummyRepository, hs.idCreator)
+	dto := new(dummyCreate.RequestDTO)
 
-	domain := dummy.Dummy{}
-	body, errors := io.ReadAll(context.Request().Body)
-	if errors != nil {
-		return context.JSON(422, errors)
-	}
-
-	errors = json.Unmarshal(body, &domain)
-	if errors != nil {
+	if errors := context.Bind(dto); errors != nil {
 		return context.JSON(422, errors)
 	}
 
 	s.Execute(
-		dummyCreate.NewRequest(domain, hs.validator),
+		dummyCreate.NewRequest(dto, hs.validator),
 	)
 	response, err := s.GetResponse()
 	if err != nil {
@@ -84,20 +82,14 @@ func (hs *DummyHandlers) HandleCreateDummy(context echo.Context) error {
 
 func (hs *DummyHandlers) HandleEditDummy(context echo.Context) error {
 	s := dummyEdit.NewService(hs.logger, hs.DummyRepository)
+	dto := new(dummyEdit.RequestDTO)
 
-	domain := dummy.Dummy{}
-	body, errors := io.ReadAll(context.Request().Body)
-	if errors != nil {
-		return context.JSON(422, errors)
-	}
-
-	errors = json.Unmarshal(body, &domain)
-	if errors != nil {
+	if errors := context.Bind(dto); errors != nil {
 		return context.JSON(422, errors)
 	}
 
 	s.Execute(
-		dummyEdit.NewRequest(domain, context.Param("dummy_id"), hs.validator),
+		dummyEdit.NewRequest(dto, hs.validator),
 	)
 
 	response, err := s.GetResponse()
@@ -121,8 +113,14 @@ func (hs *DummyHandlers) HandleListDummy(context echo.Context) error {
 
 func (hs *DummyHandlers) HandleDeleteDummy(context echo.Context) error {
 	s := dummyDelete.NewService(hs.logger, hs.DummyRepository)
+	dto := new(dummyDelete.RequestDTO)
+
+	if errors := context.Bind(dto); errors != nil {
+		return context.JSON(422, errors)
+	}
+
 	s.Execute(
-		dummyDelete.NewRequest(context.Param("dummy_id")),
+		dummyDelete.NewRequest(dto),
 	)
 	response, err := s.GetResponse()
 	if err != nil {

--- a/cmd/http/handlers/dummy.go
+++ b/cmd/http/handlers/dummy.go
@@ -46,14 +46,14 @@ func NewDummyHandlers(
 
 func (hs *DummyHandlers) HandleGetDummy(context echo.Context) error {
 	s := dummyGet.NewService(hs.logger, hs.DummyRepository)
-	dto := new(dummyGet.RequestDTO)
+	data := new(dummyGet.Data)
 
-	if errors := context.Bind(dto); errors != nil {
+	if errors := context.Bind(data); errors != nil {
 		return context.JSON(422, errors)
 	}
 
 	s.Execute(
-		dummyGet.NewRequest(dto),
+		dummyGet.NewRequest(data),
 	)
 	response, err := s.GetResponse()
 	if err != nil {
@@ -64,14 +64,14 @@ func (hs *DummyHandlers) HandleGetDummy(context echo.Context) error {
 
 func (hs *DummyHandlers) HandleCreateDummy(context echo.Context) error {
 	s := dummyCreate.NewService(hs.logger, hs.DummyRepository, hs.idCreator)
-	dto := new(dummyCreate.RequestDTO)
+	data := new(dummyCreate.Data)
 
-	if errors := context.Bind(dto); errors != nil {
+	if errors := context.Bind(data); errors != nil {
 		return context.JSON(422, errors)
 	}
 
 	s.Execute(
-		dummyCreate.NewRequest(dto, hs.validator),
+		dummyCreate.NewRequest(data, hs.validator),
 	)
 	response, err := s.GetResponse()
 	if err != nil {
@@ -82,14 +82,14 @@ func (hs *DummyHandlers) HandleCreateDummy(context echo.Context) error {
 
 func (hs *DummyHandlers) HandleEditDummy(context echo.Context) error {
 	s := dummyEdit.NewService(hs.logger, hs.DummyRepository)
-	dto := new(dummyEdit.RequestDTO)
+	data := new(dummyEdit.Data)
 
-	if errors := context.Bind(dto); errors != nil {
+	if errors := context.Bind(data); errors != nil {
 		return context.JSON(422, errors)
 	}
 
 	s.Execute(
-		dummyEdit.NewRequest(dto, hs.validator),
+		dummyEdit.NewRequest(data, hs.validator),
 	)
 
 	response, err := s.GetResponse()
@@ -113,14 +113,14 @@ func (hs *DummyHandlers) HandleListDummy(context echo.Context) error {
 
 func (hs *DummyHandlers) HandleDeleteDummy(context echo.Context) error {
 	s := dummyDelete.NewService(hs.logger, hs.DummyRepository)
-	dto := new(dummyDelete.RequestDTO)
+	data := new(dummyDelete.Data)
 
-	if errors := context.Bind(dto); errors != nil {
+	if errors := context.Bind(data); errors != nil {
 		return context.JSON(422, errors)
 	}
 
 	s.Execute(
-		dummyDelete.NewRequest(dto),
+		dummyDelete.NewRequest(data),
 	)
 	response, err := s.GetResponse()
 	if err != nil {

--- a/cmd/http/routes/auth.go
+++ b/cmd/http/routes/auth.go
@@ -1,19 +1,20 @@
 package routes
 
 import (
-	"github.com/labstack/echo/v4"
 	"go-skeleton/cmd/http/handlers"
 	"go-skeleton/pkg"
+
+	"github.com/labstack/echo/v4"
 )
 
 type Auth struct {
-	hand handlers.AuthHandlers
+	hand *handlers.AuthHandlers
 }
 
-func NewAuthRoute(
-	deps map[string]pkg.Bootable,
-) *Auth {
-	return &Auth{}
+func NewAuthRoute(deps map[string]pkg.Bootable) *Auth {
+	return &Auth{
+		hand: handlers.NewAuthHandlers(deps),
+	}
 }
 
 func (hs *Auth) DeclareRoutes(server *echo.Group) {

--- a/tools/generator/config.toml
+++ b/tools/generator/config.toml
@@ -9,7 +9,7 @@ domainPascalCase = "{{domainPascalCase}}"
 "{{validatorInject}}" = "	validator: validator,"
 "{{hsValidator}}" = "hs.validator"
 "{{,hsValidator}}" = ", hs.validator"
-"{{validatorRule}}" = """errs := r.validator.ValidateStruct(r.DTO)
+"{{validatorRule}}" = """errs := r.validator.ValidateStruct(r.Data)
 	for _, err := range errs {
 		if err != nil {
 			return err

--- a/tools/generator/config.toml
+++ b/tools/generator/config.toml
@@ -9,7 +9,7 @@ domainPascalCase = "{{domainPascalCase}}"
 "{{validatorInject}}" = "	validator: validator,"
 "{{hsValidator}}" = "hs.validator"
 "{{,hsValidator}}" = ", hs.validator"
-"{{validatorRule}}" = """errs := r.validator.ValidateStruct(r.{{domainPascalCase}})
+"{{validatorRule}}" = """errs := r.validator.ValidateStruct(r.DTO)
 	for _, err := range errs {
 		if err != nil {
 			return err

--- a/tools/generator/stubs/services/CREATE/request.go.stub
+++ b/tools/generator/stubs/services/CREATE/request.go.stub
@@ -4,19 +4,19 @@ import (
 	{{validatorImport}}
 )
 
-type RequestDTO struct {
+type Data struct {
 	{{domainPascalCase}}Id string
 }
 
 type Request struct {
-	DTO *RequestDTO
+	Data *Data
 	Err error
 	{{validator}}
 }
 
-func NewRequest(dto *RequestDTO{{,validator}}) Request {
+func NewRequest(data *Data{{,validator}}) Request {
 	return Request{
-		DTO: dto,
+		Data: data,
 		{{validatorInject}}
 	}
 }

--- a/tools/generator/stubs/services/CREATE/request.go.stub
+++ b/tools/generator/stubs/services/CREATE/request.go.stub
@@ -1,19 +1,22 @@
 package {{domain}}
 
 import (
-	domain "go-skeleton/application/domain/{{domain}}"
 	{{validatorImport}}
 )
 
+type RequestDTO struct {
+	{{domainPascalCase}}Id string
+}
+
 type Request struct {
-	{{domainPascalCase}} domain.{{domainPascalCase}}
-	Err   error
+	DTO *RequestDTO
+	Err error
 	{{validator}}
 }
 
-func NewRequest({{domain}} domain.{{domainPascalCase}}{{,validator}}) Request {
+func NewRequest(dto *RequestDTO{{,validator}}) Request {
 	return Request{
-		{{domainPascalCase}}: {{domain}},
+		DTO: dto,
 		{{validatorInject}}
 	}
 }

--- a/tools/generator/stubs/services/CREATE/service.go.stub
+++ b/tools/generator/stubs/services/CREATE/service.go.stub
@@ -31,17 +31,17 @@ func (s *Service) Execute(request Request) {
 		return
 	}
 
-	request.DTO.{{domainPascalCase}}Id = s.idCreator.Create()
-	s.produceResponseRule(request.DTO)
+	request.Data.{{domainPascalCase}}Id = s.idCreator.Create()
+	s.produceResponseRule(request.Data)
 }
 
 func (s *Service) GetResponse() (*Response, *services.Error) {
 	return s.response, s.Error
 }
 
-func (s *Service) produceResponseRule(dto *RequestDTO) {
+func (s *Service) produceResponseRule(data *Data) {
 	{{domain}} := {{domain}}.{{domainPascalCase}}{
-		{{domainPascalCase}}Id:   dto.{{domainPascalCase}}Id,
+		{{domainPascalCase}}Id:   data.{{domainPascalCase}}Id,
 	}
 
 	err := s.repository.Create(&{{domain}})

--- a/tools/generator/stubs/services/CREATE/service.go.stub
+++ b/tools/generator/stubs/services/CREATE/service.go.stub
@@ -31,15 +31,19 @@ func (s *Service) Execute(request Request) {
 		return
 	}
 
-	request.{{domainPascalCase}}.{{domainPascalCase}}Id = s.idCreator.Create()
-	s.produceResponseRule(request.{{domainPascalCase}})
+	request.DTO.{{domainPascalCase}}Id = s.idCreator.Create()
+	s.produceResponseRule(request.DTO)
 }
 
 func (s *Service) GetResponse() (*Response, *services.Error) {
 	return s.response, s.Error
 }
 
-func (s *Service) produceResponseRule({{domain}} {{domain}}.{{domainPascalCase}}) {
+func (s *Service) produceResponseRule(dto *RequestDTO) {
+	{{domain}} := {{domain}}.{{domainPascalCase}}{
+		{{domainPascalCase}}Id:   dto.{{domainPascalCase}}Id,
+	}
+
 	err := s.repository.Create(&{{domain}})
 	if err != nil {
 		s.Error = &services.Error{

--- a/tools/generator/stubs/services/DELETE/request.go.stub
+++ b/tools/generator/stubs/services/DELETE/request.go.stub
@@ -4,18 +4,18 @@ import (
 	{{validatorImport}}
 )
 
-type RequestDTO struct {
+type Data struct {
 	{{domainPascalCase}}Id string `param:"{{domain}}_id"`
 }
 
 type Request struct {
-	DTO *RequestDTO
+	Data *Data
 	err error
 }
 
-func NewRequest(dto *RequestDTO{{,validator}}) Request {
+func NewRequest(data *Data{{,validator}}) Request {
 	return Request{
-		DTO: dto,
+		Data: data,
 	}
 }
 

--- a/tools/generator/stubs/services/DELETE/request.go.stub
+++ b/tools/generator/stubs/services/DELETE/request.go.stub
@@ -1,20 +1,21 @@
 package {{domain}}
 
 import (
-	domain "go-skeleton/application/domain/{{domain}}"
 	{{validatorImport}}
 )
 
-type Request struct {
-	{{domainPascalCase}} domain.{{domainPascalCase}}
-	err   error
+type RequestDTO struct {
+	{{domainPascalCase}}Id string `param:"{{domain}}_id"`
 }
 
-func NewRequest({{domain}}Id string{{,validator}}) Request {
+type Request struct {
+	DTO *RequestDTO
+	err error
+}
+
+func NewRequest(dto *RequestDTO{{,validator}}) Request {
 	return Request{
-		{{domainPascalCase}}: domain.{{domainPascalCase}}{
-			{{domainPascalCase}}Id: {{domain}}Id,
-		},
+		DTO: dto,
 	}
 }
 

--- a/tools/generator/stubs/services/DELETE/service.go.stub
+++ b/tools/generator/stubs/services/DELETE/service.go.stub
@@ -27,18 +27,18 @@ func (s *Service) Execute(request Request) {
 		s.BadRequest(request, err)
 		return
 	}
-	s.produceResponseRule(request.DTO)
+	s.produceResponseRule(request.Data)
 }
 
 func (s *Service) GetResponse() (*Response, *services.Error) {
 	return s.response, s.Error
 }
 
-func (s *Service) produceResponseRule(dto *RequestDTO) {
+func (s *Service) produceResponseRule(data *Data) {
 	s.Logger.Debug("ProduceResponseRule")
 
 	{{domain}} := {{domain}}.{{domainPascalCase}}{
-		{{domainPascalCase}}Id: dto.{{domainPascalCase}}Id,
+		{{domainPascalCase}}Id: data.{{domainPascalCase}}Id,
 	}
 
 	err := s.repository.Delete(&{{domain}})

--- a/tools/generator/stubs/services/DELETE/service.go.stub
+++ b/tools/generator/stubs/services/DELETE/service.go.stub
@@ -27,16 +27,21 @@ func (s *Service) Execute(request Request) {
 		s.BadRequest(request, err)
 		return
 	}
-	s.produceResponseRule(request.{{domainPascalCase}})
+	s.produceResponseRule(request.DTO)
 }
 
 func (s *Service) GetResponse() (*Response, *services.Error) {
 	return s.response, s.Error
 }
 
-func (s *Service) produceResponseRule(d {{domain}}.{{domainPascalCase}}) {
+func (s *Service) produceResponseRule(dto *RequestDTO) {
 	s.Logger.Debug("ProduceResponseRule")
-	err := s.repository.Delete(&d)
+
+	{{domain}} := {{domain}}.{{domainPascalCase}}{
+		{{domainPascalCase}}Id: dto.{{domainPascalCase}}Id,
+	}
+
+	err := s.repository.Delete(&{{domain}})
 	if err != nil {
 			s.Error = &services.Error{
 					Status:  400,

--- a/tools/generator/stubs/services/EDIT/request.go.stub
+++ b/tools/generator/stubs/services/EDIT/request.go.stub
@@ -2,23 +2,23 @@ package {{domain}}
 
 import (
 	"errors"
-	domain "go-skeleton/application/domain/{{domain}}"
 	{{validatorImport}}
 )
 
+type RequestDTO struct {
+	{{domainPascalCase}}Id string `param:"{{domain}}_id"`
+}
+
 type Request struct {
-	{{domainPascalCase}}   domain.{{domainPascalCase}}
-	{{domainPascalCase}}id string
+	DTO *RequestDTO
 	{{validator}}
 }
 
-func NewRequest({{domain}} domain.{{domainPascalCase}}, {{domain}}Id string{{,validator}}) Request {
-	req := Request{
-		{{domainPascalCase}}: {{domain}},
+func NewRequest(dto *RequestDTO{{,validator}}) Request {
+	return Request{
+		DTO: dto,
 		{{validatorInject}}
 	}
-	req.{{domainPascalCase}}.{{domainPascalCase}}Id = {{domain}}Id
-	return req
 }
 
 func (r *Request) Validate() error {
@@ -30,7 +30,7 @@ func (r *Request) Validate() error {
 }
 
 func (r *Request) {{domain}}IdRule() error {
-	if r.{{domainPascalCase}}.{{domainPascalCase}}Id == `""` {
+	if r.DTO.{{domainPascalCase}}Id == `""` {
 		return errors.New("invalid_argument")
 	}
 	return nil

--- a/tools/generator/stubs/services/EDIT/request.go.stub
+++ b/tools/generator/stubs/services/EDIT/request.go.stub
@@ -5,18 +5,18 @@ import (
 	{{validatorImport}}
 )
 
-type RequestDTO struct {
+type Data struct {
 	{{domainPascalCase}}Id string `param:"{{domain}}_id"`
 }
 
 type Request struct {
-	DTO *RequestDTO
+	Data *Data
 	{{validator}}
 }
 
-func NewRequest(dto *RequestDTO{{,validator}}) Request {
+func NewRequest(data *Data{{,validator}}) Request {
 	return Request{
-		DTO: dto,
+		Data: data,
 		{{validatorInject}}
 	}
 }
@@ -30,7 +30,7 @@ func (r *Request) Validate() error {
 }
 
 func (r *Request) {{domain}}IdRule() error {
-	if r.DTO.{{domainPascalCase}}Id == `""` {
+	if r.Data.{{domainPascalCase}}Id == `""` {
 		return errors.New("invalid_argument")
 	}
 	return nil

--- a/tools/generator/stubs/services/EDIT/service.go.stub
+++ b/tools/generator/stubs/services/EDIT/service.go.stub
@@ -28,16 +28,21 @@ func (s *Service) Execute(request Request) {
 		return
 	}
 
-	s.produceResponseRule(&request.{{domainPascalCase}})
+	s.produceResponseRule(request.DTO)
 }
 
 func (s *Service) GetResponse() (*Response, *services.Error) {
 	return s.response, s.Error
 }
 
-func (s *Service) produceResponseRule({{domain}} *{{domain}}.{{domainPascalCase}}) {
+func (s *Service) produceResponseRule(dto *RequestDTO) {
 	s.Logger.Debug("ProduceResponseRule")
-	err := s.repository.Edit({{domain}})
+
+	{{domain}} := {{domain}}.{{domainPascalCase}}{
+		{{domainPascalCase}}Id: dto.{{domainPascalCase}}Id,
+	}
+
+	err := s.repository.Edit(&{{domain}})
 	if err != nil {
 			s.Error = &services.Error{
 					Status:  400,

--- a/tools/generator/stubs/services/EDIT/service.go.stub
+++ b/tools/generator/stubs/services/EDIT/service.go.stub
@@ -28,18 +28,18 @@ func (s *Service) Execute(request Request) {
 		return
 	}
 
-	s.produceResponseRule(request.DTO)
+	s.produceResponseRule(request.Data)
 }
 
 func (s *Service) GetResponse() (*Response, *services.Error) {
 	return s.response, s.Error
 }
 
-func (s *Service) produceResponseRule(dto *RequestDTO) {
+func (s *Service) produceResponseRule(data *Data) {
 	s.Logger.Debug("ProduceResponseRule")
 
 	{{domain}} := {{domain}}.{{domainPascalCase}}{
-		{{domainPascalCase}}Id: dto.{{domainPascalCase}}Id,
+		{{domainPascalCase}}Id: data.{{domainPascalCase}}Id,
 	}
 
 	err := s.repository.Edit(&{{domain}})

--- a/tools/generator/stubs/services/GET/request.go.stub
+++ b/tools/generator/stubs/services/GET/request.go.stub
@@ -2,19 +2,21 @@ package {{domain}}
 
 import (
 	"errors"
-	domain "go-skeleton/application/domain/{{domain}}"
 )
 
-type Request struct {
-	{{domainPascalCase}} domain.{{domainPascalCase}}
-	Err   error
+type RequestDTO struct {
+	{{domainPascalCase}}Id string `param:"{{domain}}_id"`
 }
 
-func NewRequest({{domain}}Id string) Request {
+
+type Request struct {
+	DTO *RequestDTO
+	Err error
+}
+
+func NewRequest(dto *RequestDTO) Request {
 	return Request{
-		{{domainPascalCase}}: domain.{{domainPascalCase}}{
-			{{domainPascalCase}}Id: {{domain}}Id,
-		},
+		DTO: dto,
 	}
 }
 
@@ -26,7 +28,7 @@ func (r *Request) Validate() error {
 }
 
 func (r *Request) {{domain}}IdRule() error {
-	if r.{{domainPascalCase}}.{{domainPascalCase}}Id == `""` {
+	if r.DTO.{{domainPascalCase}}Id == `""` {
 		return errors.New("invalid_argument")
 	}
 	return nil

--- a/tools/generator/stubs/services/GET/request.go.stub
+++ b/tools/generator/stubs/services/GET/request.go.stub
@@ -4,19 +4,19 @@ import (
 	"errors"
 )
 
-type RequestDTO struct {
+type Data struct {
 	{{domainPascalCase}}Id string `param:"{{domain}}_id"`
 }
 
 
 type Request struct {
-	DTO *RequestDTO
+	Data *Data
 	Err error
 }
 
-func NewRequest(dto *RequestDTO) Request {
+func NewRequest(data *Data) Request {
 	return Request{
-		DTO: dto,
+		Data: data,
 	}
 }
 
@@ -28,7 +28,7 @@ func (r *Request) Validate() error {
 }
 
 func (r *Request) {{domain}}IdRule() error {
-	if r.DTO.{{domainPascalCase}}Id == `""` {
+	if r.Data.{{domainPascalCase}}Id == `""` {
 		return errors.New("invalid_argument")
 	}
 	return nil

--- a/tools/generator/stubs/services/GET/service.go.stub
+++ b/tools/generator/stubs/services/GET/service.go.stub
@@ -27,16 +27,16 @@ func (s *Service) Execute(request Request) {
 		s.BadRequest(request, err)
 		return
 	}
-	s.produceResponseRule(request.{{domainPascalCase}}.{{domainPascalCase}}Id)
+	s.produceResponseRule(request.DTO)
 }
 
 func (s *Service) GetResponse() (*Response, *services.Error) {
 	return s.response, s.Error
 }
 
-func (s *Service) produceResponseRule(id string) {
+func (s *Service) produceResponseRule(dto *RequestDTO) {
 	s.Logger.Debug("ProduceResponseRule")
-	{{domain}}Data, err := s.repository.Get(id)
+	{{domain}}Data, err := s.repository.Get(dto.{{domainPascalCase}}Id)
 	if err != nil {
 			s.Error = &services.Error{
 					Status:  400,

--- a/tools/generator/stubs/services/GET/service.go.stub
+++ b/tools/generator/stubs/services/GET/service.go.stub
@@ -27,16 +27,16 @@ func (s *Service) Execute(request Request) {
 		s.BadRequest(request, err)
 		return
 	}
-	s.produceResponseRule(request.DTO)
+	s.produceResponseRule(request.Data)
 }
 
 func (s *Service) GetResponse() (*Response, *services.Error) {
 	return s.response, s.Error
 }
 
-func (s *Service) produceResponseRule(dto *RequestDTO) {
+func (s *Service) produceResponseRule(data *Data) {
 	s.Logger.Debug("ProduceResponseRule")
-	{{domain}}Data, err := s.repository.Get(dto.{{domainPascalCase}}Id)
+	{{domain}}Data, err := s.repository.Get(data.{{domainPascalCase}}Id)
 	if err != nil {
 			s.Error = &services.Error{
 					Status:  400,


### PR DESCRIPTION
Criando nova estrutura de DTO do serviço para sinalizar os dados de entrada, e utilizando o `Bind` do `Echo` (https://echo.labstack.com/docs/binding) para ser possível pegar valores de diferentes métodos (`param`, `json`) quando `http`.